### PR TITLE
add type-checking to filters

### DIFF
--- a/flask_filter/filters/filters.py
+++ b/flask_filter/filters/filters.py
@@ -57,7 +57,6 @@ class Filter(abc.ABC):
         return value
 
 
-
 class RelativeComparator(Filter):
 
     def is_valid(self):
@@ -143,7 +142,7 @@ class NotEqualsFilter(Filter):
 
     def is_valid(self):
         try:
-            assert type(self.value) in (str, int)
+            assert type(self.value) in (str, int, datetime.date)
         except AssertionError:
             raise ValidationError(f"{self} requires a string or int value")
 

--- a/flask_filter/filters/filters.py
+++ b/flask_filter/filters/filters.py
@@ -1,7 +1,13 @@
 import abc
+import datetime
+import re
 
 from typing import Any
+from numbers import Number
 from marshmallow.exceptions import ValidationError
+
+
+RE_DATE = "^([0-9]{4})-([0-9]|1[0-2]|0[1-9])-([1-9]|0[1-9]|1[0-9]|2[1-9]|3[0-1])$"
 
 
 class Filter(abc.ABC):
@@ -9,7 +15,8 @@ class Filter(abc.ABC):
 
     def __init__(self, field: str, value: Any):
         self.field = field
-        self.value = value
+        self.value = self._date_or_value(value)
+        self.is_valid()
 
     def __repr__(self):
         return f"<{type(self).__name__}(field='{self.field}', op='{self.OP}'" \
@@ -25,6 +32,10 @@ class Filter(abc.ABC):
     def apply(self, query, class_, schema):
         raise NotImplementedError('apply is an abstract method')
 
+    @abc.abstractmethod
+    def is_valid(self):
+        raise NotImplementedError('is_valid is an abstract method')
+
     def _get_db_field(self, schema):
         """ private method to convert JSON field to SQL column
 
@@ -38,8 +49,26 @@ class Filter(abc.ABC):
             raise ValidationError("'{}' is not a valid field")
         return attr.attribute or self.field
 
+    def _date_or_value(self, value):
+        if not isinstance(value, str):
+            return value
+        if re.match(RE_DATE, value):
+            return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+        return value
 
-class LTFilter(Filter):
+
+
+class RelativeComparator(Filter):
+
+    def is_valid(self):
+        try:
+            allowed = (Number, datetime.date, datetime.datetime)
+            assert isinstance(self.value, allowed)
+        except AssertionError:
+            raise ValidationError(f"{self} requires an ordinal value")
+
+
+class LTFilter(RelativeComparator):
     OP = "<"
 
     def apply(self, query, class_, schema=None):
@@ -47,12 +76,28 @@ class LTFilter(Filter):
         return query.filter(getattr(class_, field) < self.value)
 
 
-class LTEFilter(Filter):
+class LTEFilter(RelativeComparator):
     OP = "<="
 
     def apply(self, query, class_, schema=None):
         field = self._get_db_field(schema)
         return query.filter(getattr(class_, field) <= self.value)
+
+
+class GTFilter(RelativeComparator):
+    OP = ">"
+
+    def apply(self, query, class_, schema=None):
+        field = self._get_db_field(schema)
+        return query.filter(getattr(class_, field) > self.value)
+
+
+class GTEFilter(RelativeComparator):
+    OP = ">="
+
+    def apply(self, query, class_, schema=None):
+        field = self._get_db_field(schema)
+        return query.filter(getattr(class_, field) >= self.value)
 
 
 class EqualsFilter(Filter):
@@ -62,29 +107,31 @@ class EqualsFilter(Filter):
         field = self._get_db_field(schema)
         return query.filter(getattr(class_, field) == self.value)
 
-
-class GTFilter(Filter):
-    OP = ">"
-
-    def apply(self, query, class_, schema=None):
-        field = self._get_db_field(schema)
-        return query.filter(getattr(class_, field) > self.value)
-
-
-class GTEFilter(Filter):
-    OP = ">="
-
-    def apply(self, query, class_, schema=None):
-        field = self._get_db_field(schema)
-        return query.filter(getattr(class_, field) >= self.value)
+    def is_valid(self):
+        allowed = (str, int, datetime.date)
+        try:
+            assert isinstance(self.value, allowed)
+        except AssertionError:
+            raise ValidationError(f"{self} requires a string or int value")
 
 
 class InFilter(Filter):
     OP = "in"
 
+    def __init__(self, field: str, value: Any):
+        if isinstance(value, str):
+            value = [value]
+        super().__init__(field, value)
+
     def apply(self, query, class_, schema=None):
         field = self._get_db_field(schema)
-        return query.filter(getattr(class_, field).in_(self.value))
+        return query.filter(getattr(class_, field).in_(list(self.value)))
+
+    def is_valid(self):
+        try:
+            _ = (e for e in self.value)
+        except TypeError:
+            raise ValidationError(f"{self} must be an iterable")
 
 
 class NotEqualsFilter(Filter):
@@ -94,6 +141,12 @@ class NotEqualsFilter(Filter):
         field = self._get_db_field(schema)
         return query.filter(getattr(class_, field) != self.value)
 
+    def is_valid(self):
+        try:
+            assert type(self.value) in (str, int)
+        except AssertionError:
+            raise ValidationError(f"{self} requires a string or int value")
+
 
 class LikeFilter(Filter):
     OP = "like"
@@ -101,3 +154,9 @@ class LikeFilter(Filter):
     def apply(self, query, class_, schema=None):
         field = self._get_db_field(schema)
         return query.filter(getattr(class_, field).like(self.value))
+
+    def is_valid(self):
+        try:
+            assert isinstance(self.value, str)
+        except AssertionError:
+            raise ValidationError(f"{self} requires a string with a wildcard")

--- a/tests/minipet_app.py
+++ b/tests/minipet_app.py
@@ -12,6 +12,8 @@ filtr = FlaskFilter()
 
 def create_app(env='test'):
     app = Flask('Mini Pet Store')
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     db.init_app(app)
     filtr.init_app(app)
     filtr.register_model(Dog, DogSchema)

--- a/tests/test_filter_typecheck.py
+++ b/tests/test_filter_typecheck.py
@@ -142,3 +142,42 @@ class FilterSchemaTestClass(unittest.TestCase):
         self.assertIsInstance(infilter, InFilter)
         self.assertEqual(infilter.value, ["Fido"])
 
+    def test_notequalsfilter_accepts_string(self):
+        json = {"field": "name", "op": "!=", "value": "Fido"}
+        notequalsfilter = self.schema.load(json)
+        self.assertIsInstance(notequalsfilter, NotEqualsFilter)
+
+    def test_notequalsfilter_accepts_int(self):
+        json = {"field": "age", "op": "!=", "value": 10}
+        notequalsfilter = self.schema.load(json)
+        self.assertIsInstance(notequalsfilter, NotEqualsFilter)
+
+    def test_notequalsfilter_accepts_date(self):
+        json = {"field": "name", "op": "!=", "value": date(2018, 12, 16)}
+        notequalsfilter = self.schema.load(json)
+        self.assertIsInstance(notequalsfilter, NotEqualsFilter)
+
+    def test_notequalsfilter_fails_on_float(self):
+        json = {"field": "age", "op": "!=", "value": 10.234}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_likefilter_accepts_strings(self):
+        json = {"field": "name", "op": "like", "value": "Fido%"}
+        likefilter = self.schema.load(json)
+        self.assertIsInstance(likefilter, LikeFilter)
+
+    def test_likefilter_fails_on_int(self):
+        json = {"field": "age", "op": "like", "value": 4}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_likefilter_fails_on_float(self):
+        json = {"field": "age", "op": "like", "value": 4.20}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_likefilter_fails_on_date(self):
+        json = {"field": "dateOfBirth", "op": "like", "value": date(2018, 12, 17)}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)

--- a/tests/test_filter_typecheck.py
+++ b/tests/test_filter_typecheck.py
@@ -1,0 +1,144 @@
+import datetime
+from datetime import date
+import unittest
+
+from marshmallow.exceptions import ValidationError
+
+from flask_filter.schemas import FilterSchema
+from flask_filter.filters import *
+
+
+class FilterSchemaTestClass(unittest.TestCase):
+
+    def setUp(self):
+        self.schema = FilterSchema()
+
+    def tearDown(self):
+        self.schema = None
+
+    def test_ltfilter_accepts_floats(self):
+        json = {"field": "weight", "op": "<", "value": 10.24}
+        lt = self.schema.load(json)
+        self.assertIsInstance(lt, LTFilter)
+
+    def test_ltfilter_accepts_ints(self):
+        json = {"field": "weight", "op": "<", "value": 10}
+        lt = self.schema.load(json)
+        self.assertIsInstance(lt, LTFilter)
+
+    def test_ltfilter_accepts_dates(self):
+        json = {"field": "dateOfBirth", "op": "<", "value": "2018-12-15"}
+        lt = self.schema.load(json)
+        self.assertIsInstance(lt, LTFilter)
+        self.assertIsInstance(lt.value, datetime.date)
+
+    def test_ltfilter_raises_validationerror_against_string(self):
+        json = {"field": "name", "op": "<", "value": "Fido"}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_ltefilter_accepts_floats(self):
+        json = {"field": "weight", "op": "<=", "value": 10.24}
+        lte = self.schema.load(json)
+        self.assertIsInstance(lte, LTEFilter)
+
+    def test_ltefilter_accepts_ints(self):
+        json = {"field": "weight", "op": "<=", "value": 10}
+        lte = self.schema.load(json)
+        self.assertIsInstance(lte, LTEFilter)
+
+    def test_ltefilter_accepts_dates(self):
+        json = {"field": "dateOfBirth", "op": "<=", "value": "2018-12-15"}
+        lte = self.schema.load(json)
+        self.assertIsInstance(lte, LTEFilter)
+        self.assertIsInstance(lte.value, datetime.date)
+
+    def test_ltefilter_raises_validationerror_against_string(self):
+        json = {"field": "name", "op": "<=", "value": "Fido"}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_gtfilter_accepts_floats(self):
+        json = {"field": "weight", "op": ">", "value": 10.24}
+        gt = self.schema.load(json)
+        self.assertIsInstance(gt, GTFilter)
+
+    def test_gtfilter_accepts_ints(self):
+        json = {"field": "weight", "op": ">", "value": 10}
+        gt = self.schema.load(json)
+        self.assertIsInstance(gt, GTFilter)
+
+    def test_gtfilter_accepts_dates(self):
+        json = {"field": "dateOfBirth", "op": ">", "value": "2018-12-15"}
+        gt = self.schema.load(json)
+        self.assertIsInstance(gt, GTFilter)
+        self.assertIsInstance(gt.value, datetime.date)
+
+    def test_gtfilter_raises_validationerror_against_string(self):
+        json = {"field": "name", "op": ">", "value": "Fido"}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_gtefilter_accepts_floats(self):
+        json = {"field": "weight", "op": ">=", "value": 10.24}
+        gte = self.schema.load(json)
+        self.assertIsInstance(gte, GTEFilter)
+
+    def test_gtefilter_accepts_ints(self):
+        json = {"field": "weight", "op": ">=", "value": 10}
+        gte = self.schema.load(json)
+        self.assertIsInstance(gte, GTEFilter)
+
+    def test_gtefilter_accepts_dates(self):
+        json = {"field": "dateOfBirth", "op": ">=", "value": "2018-12-15"}
+        gte = self.schema.load(json)
+        self.assertIsInstance(gte, GTEFilter)
+        self.assertIsInstance(gte.value, datetime.date)
+
+    def test_gtefilter_raises_validationerror_against_string(self):
+        json = {"field": "name", "op": ">=", "value": "Fido"}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_equalfilter_accepts_ints(self):
+        json = {"field": "weight", "op": "=", "value": 10}
+        eq = self.schema.load(json)
+        self.assertIsInstance(eq, EqualsFilter)
+
+    def test_equalfilter_accepts_strings(self):
+        json = {"field": "name", "op": "=", "value": "Fido"}
+        eq = self.schema.load(json)
+        self.assertIsInstance(eq, EqualsFilter)
+
+    def test_equalfilter_accepts_dates(self):
+        json = {"field": "name", "op": "=", "value": "2018-12-15"}
+        eq = self.schema.load(json)
+        self.assertIsInstance(eq, EqualsFilter)
+
+    def test_equalsfilter_raises_validationerror_against_float(self):
+        json = {"field": "weight", "op": "=", "value": 12.345}
+        with self.assertRaises(ValidationError):
+            self.schema.load(json)
+
+    def test_infilter_accepts_list_of_ints(self):
+        json = {"field": "weight", "op": "in", "value": [1, 2, 3]}
+        infilter = self.schema.load(json)
+        self.assertIsInstance(infilter, InFilter)
+
+    def test_infilter_accepts_list_of_strings(self):
+        json = {"field": "weight", "op": "in", "value": ['A', 'B', 'C']}
+        infilter = self.schema.load(json)
+        self.assertIsInstance(infilter, InFilter)
+
+    def test_infilter_accepts_list_of_dates(self):
+        dates = [date(2018, 12, 15), date(2018, 12, 16)]
+        json = {"field": "weight", "op": "in", "value": dates}
+        infilter = self.schema.load(json)
+        self.assertIsInstance(infilter, InFilter)
+
+    def test_infilter_accepts_string_and_converts_to_list(self):
+        json = {"field": "name", "op": "in", "value": "Fido"}
+        infilter = self.schema.load(json)
+        self.assertIsInstance(infilter, InFilter)
+        self.assertEqual(infilter.value, ["Fido"])
+


### PR DESCRIPTION
Filter objects break a comparator (i.e. "age < 25") into three components `{"field": "age", "op": "<", "value": 25}`. The "field" and "op" fields expect strings, but the "value" field must naturally accept any type. Consequently, the `FilterSchema` itself cannot type-check "value" and must delegate the type checking to the `Filter` class family.

This PR adds an abstract `is_valid` method to the base `Filter` class (invoked during initialization, after setting `self.value` and `self.field`) and corresponding implementations to its sub-classes. 

Since several `Filter` implementors (`LTFilter`, `LTEFilter`, `GTFilter`, `GTEFilter`) all should use the same implementation of `is_valid`, I have also created a common implementation called `RelativeComparator` that is a subclass of `Filter`. Each of the filters listed above inherits their `is_valid` method from `RelativeComparator`.