### PR TITLE
Marshmallow 2 Support

### DIFF
--- a/documentation/source/changelog.rst
+++ b/documentation/source/changelog.rst
@@ -1,0 +1,9 @@
+Changelog
+=========
+The Change Log for this project contains all meaningful changes to the function
+of the code base. It does not necessarily include changes to the form of the
+code, i.e. refactoring.
+
+* 2020-09-08 (v0.1.0dev5): added support for Marshmallow 2, along with a
+  deprecation warning that it will be removed in future versions. This was
+  implemented via a deserializer function located in the "schemas" module.

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -22,6 +22,7 @@ standardized search function to REST APIs.
 
    tutorial
    dev-guide
+   changelog
 
 
 

--- a/flask_filter/__init__.py
+++ b/flask_filter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0dev4'
+__version__ = '0.1.0dev5'
 __author__ = 'Exley McCormick'
 __email__ = 'exleym@gmail.com'
 

--- a/flask_filter/base.py
+++ b/flask_filter/base.py
@@ -2,8 +2,7 @@ from flask import Flask
 from flask_sqlalchemy import Model
 from marshmallow import Schema
 from typing import Union
-
-from flask_filter.schemas import FilterSchema
+from flask_filter.schemas import deserialize_filters
 
 
 
@@ -12,7 +11,6 @@ class FlaskFilter(object):
 
     def __init__(self, app: Flask = None):
         self.app = app
-        self.schema = FilterSchema()
         if self.app:
             self.init_app(app)
 
@@ -26,7 +24,7 @@ class FlaskFilter(object):
     def search(self, DbModel: Model, filters: list,
                ModelSchema: Union[Schema, None] = None,
                limit: int = None, order_by=None):
-        filters = self.schema.load(filters, many=True)
+        filters = deserialize_filters(filters, many=True)
         schema = ModelSchema or self._lookup_schema(DbModel)
         query = DbModel.query
         for f in filters:

--- a/flask_filter/query_filter.py
+++ b/flask_filter/query_filter.py
@@ -1,11 +1,8 @@
-from .schemas import FilterSchema
-
-
-filter_schema = FilterSchema()
+from .schemas import deserialize_filters
 
 
 def query_with_filters(class_, filters, schema=None, order_by=None):
-    _filters = filter_schema.load(filters, many=True)
+    _filters = deserialize_filters(filters, many=True)
     query = class_.query
     for f in _filters:
         query = f.apply(query, class_, schema)

--- a/flask_filter/schemas.py
+++ b/flask_filter/schemas.py
@@ -1,10 +1,13 @@
-from marshmallow import Schema, fields, post_load
+import logging
+import marshmallow as ma
 from marshmallow.exceptions import ValidationError
 from flask_filter.filters import FILTERS
 
 
 __FILTER_MAP = {c.OP: c for c in FILTERS}
 __VALID_OPERATORS = {x.OP for x in FILTERS}
+_mm2 = ma.__version_info__[0] == 2
+logger = logging.getLogger(__name__)
 
 
 def _get_filter_class(operator):
@@ -17,15 +20,32 @@ def vali1date_operator(value):
         raise ValidationError(message)
 
 
-class FilterSchema(Schema):
-    field = fields.String(required=True, allow_none=False)
-    op = fields.String(required=True, attribute="OP", validate=vali1date_operator)
-    value = fields.Field(required=True, allow_none=False)
+class FilterSchema(ma.Schema):
+    field = ma.fields.String(required=True, allow_none=False)
+    op = ma.fields.String(required=True, attribute="OP", validate=vali1date_operator)
+    value = ma.fields.Field(required=True, allow_none=False)
 
-    @post_load
+    @ma.post_load
     def make_object(self, json, *args, **kwargs):
         op = json.get("OP")
         field = json.get("field")
         value = json.get("value")
         Class = _get_filter_class(op)
         return Class(field=field, value=value)
+
+
+_schema = FilterSchema()
+
+
+def deserialize_filters(data, *args, **kwargs):
+    """ centralizes marshmallow v2/v3 api change handling to one place.
+    in future version of this we can remove all mm2 support and this
+    function will be a one-liner.
+    """
+    data = _schema.load(data, *args, **kwargs)
+    if _mm2:
+        logger.warning(f"Marshmallow v2 is deprecated and will not be "
+                       f"supported in future versions of FlaskFilter. "
+                       f"Please upgrade to Marshmallow 3+")
+        data = data.data
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,14 @@ chardet==3.0.4
 Click==7.0
 coverage==4.5.4
 docutils==0.14
-Flask==1.0.2
+Flask==1.1.2
 flask-marshmallow==0.9.0
 Flask-SQLAlchemy==2.3.2
 idna==2.8
 imagesize==1.1.0
 importlib-metadata==0.23
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.11.2
 MarkupSafe==1.1.0
 marshmallow==3.2.0
 marshmallow-sqlalchemy==0.15.0
@@ -36,7 +36,7 @@ six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.8.2
 sphinxcontrib-websupport==1.1.0
-SQLAlchemy==1.2.14
+SQLAlchemy==1.3.19
 tqdm==4.36.1
 twine==2.0.0
 urllib3==1.24.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='Flask-Filter',
-    version='0.1.0dev4',
+    version='0.1.0dev5',
     author="Exley McCormick",
     author_email="exleym@gmail.com",
     description="A Flask extension for creating standard resource searches",

--- a/tests/test_ordered_search.py
+++ b/tests/test_ordered_search.py
@@ -65,7 +65,7 @@ class FlaskFilterOrderTestClass(unittest.TestCase):
         xfilters = []
         with self.app.app_context():
             dags = self.filtr.search(Dog, xfilters, DogSchema)
-        self.assertEquals(len(dags), 5)
+        self.assertEqual(len(dags), 5)
         self.assertListEqual([d.id for d in dags], [1, 2, 3, 4, 5])
 
     def test_no_filter_order_by_name(self):
@@ -74,7 +74,7 @@ class FlaskFilterOrderTestClass(unittest.TestCase):
         with self.app.app_context():
             dags = self.filtr.search(Dog, xfilters, DogSchema,
                                      order_by=Dog.name)
-        self.assertEquals(len(dags), 5)
+        self.assertEqual(len(dags), 5)
         self.assertListEqual([d.id for d in dags], expected_order)
 
     def test_no_filter_order_by_name_as_string(self):
@@ -83,7 +83,7 @@ class FlaskFilterOrderTestClass(unittest.TestCase):
         with self.app.app_context():
             dags = self.filtr.search(Dog, xfilters, DogSchema,
                                      order_by="name")
-        self.assertEquals(len(dags), 5)
+        self.assertEqual(len(dags), 5)
         self.assertListEqual([d.id for d in dags], expected_order)
 
     def test_no_filter_order_by_weight(self):
@@ -92,7 +92,7 @@ class FlaskFilterOrderTestClass(unittest.TestCase):
         with self.app.app_context():
             dags = self.filtr.search(Dog, xfilters, DogSchema,
                                      order_by=Dog.weight)
-        self.assertEquals(len(dags), 5)
+        self.assertEqual(len(dags), 5)
         self.assertListEqual([d.id for d in dags], expected_order)
 
     def test_no_filter_order_by_weight_as_string(self):
@@ -101,7 +101,7 @@ class FlaskFilterOrderTestClass(unittest.TestCase):
         with self.app.app_context():
             dags = self.filtr.search(Dog, xfilters, DogSchema,
                                      order_by="weight")
-        self.assertEquals(len(dags), 5)
+        self.assertEqual(len(dags), 5)
         self.assertListEqual([d.id for d in dags], expected_order)
 
     def test_query_with_filters_function(self):
@@ -110,5 +110,5 @@ class FlaskFilterOrderTestClass(unittest.TestCase):
         with self.app.app_context():
             dags = query_with_filters(Dog, xfilters, DogSchema,
                                      order_by=Dog.weight)
-        self.assertEquals(len(dags), 5)
+        self.assertEqual(len(dags), 5)
         self.assertListEqual([d.id for d in dags], expected_order)


### PR DESCRIPTION
Original implementation was incompatible with marshmallow 2. With very little overhead, it is possible to make the library 2/3 compatible.

Added a deserializer function to `schemas.py` module that manages the 2/3 api resolution (and contains it to a single location). In future releases if we decide to remove MM2 support (or do any other filter processing) we can do so in this deserializer function.